### PR TITLE
elasticsearch.yml: xpack settings added only if es_enable_xpack

### DIFF
--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -23,6 +23,8 @@ path.data: {{ data_dirs | array_to_str }}
 
 path.logs: {{ log_dir }}
 
+{% if es_enable_xpack %}
+
 {% if not "security" in es_xpack_features %}
 xpack.security.enabled: false
 {% endif %}
@@ -41,4 +43,6 @@ xpack.ml.enabled: false
 
 {% if not "graph" in es_xpack_features %}
 xpack.graph.enabled: false
+{% endif %}
+
 {% endif %}


### PR DESCRIPTION
Prevent the following exception:
    java.lang.IllegalArgumentException: unknown setting [xpack.security.enabled] please check that any required plugins are installed